### PR TITLE
Add Attributes

### DIFF
--- a/Test Client/MainWindow.xaml.cs
+++ b/Test Client/MainWindow.xaml.cs
@@ -65,8 +65,9 @@ namespace Test_Client
         /// </summary>
         /// <param name="sender">Object selecting the variable</param>
         /// <param name="args">Parameters of the selection</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Required by API")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Required by Event API")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Bug in VS doesn't see usage in MainWindow.xaml")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "Bug in VS doesn't see the need for suppression when the item needing it is suppressed")]
         private void TvVariables_Tapped(object sender, Microsoft.UI.Xaml.Input.TappedRoutedEventArgs e)
         {
             if (tvVariables.SelectedItem != null)

--- a/Test PLC/Test PLC.tsproj
+++ b/Test PLC/Test PLC.tsproj
@@ -9,8 +9,8 @@
 			</Tasks>
 		</System>
 		<Plc>
-			<Project GUID="{3ADBE842-F389-4436-9162-CECC5F438944}" Name="Tester" PrjFilePath="Tester\Tester.plcproj" TmcFilePath="Tester\Tester.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{185797FC-FEA8-5B56-9B18-CD80A534325A}" TmcPath="Tester\Tester.tmc">
+			<Project GUID="{3ADBE842-F389-4436-9162-CECC5F438944}" Name="Tester" PrjFilePath="Tester\Tester.plcproj" TmcFilePath="Tester\Tester.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" CopyTmcToTarget="true" CopyTpyToTarget="false" SymbolicMapping="true">
+				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{7062C513-EDC7-6C06-7212-694C8C8D37D1}" TmcPath="Tester\Tester.tmc">
 					<Name>Tester Instance</Name>
 					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 					<Contexts>

--- a/Test PLC/Test PLC.tsproj
+++ b/Test PLC/Test PLC.tsproj
@@ -10,7 +10,7 @@
 		</System>
 		<Plc>
 			<Project GUID="{3ADBE842-F389-4436-9162-CECC5F438944}" Name="Tester" PrjFilePath="Tester\Tester.plcproj" TmcFilePath="Tester\Tester.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{D109D7B6-A254-0E44-E10F-97F615EDBE9F}" TmcPath="Tester\Tester.tmc">
+				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{185797FC-FEA8-5B56-9B18-CD80A534325A}" TmcPath="Tester\Tester.tmc">
 					<Name>Tester Instance</Name>
 					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 					<Contexts>

--- a/Test PLC/Tester/GVLs/GVL_System.TcGVL
+++ b/Test PLC/Tester/GVLs/GVL_System.TcGVL
@@ -2,6 +2,7 @@
 <TcPlcObject Version="1.1.0.1">
   <GVL Name="GVL_System" Id="{c3d8c51c-fae2-4924-8fe6-cd72cb5635bb}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'NotBlockWritable'}
 VAR_GLOBAL
 	(* Timestamp for cycle in ISO 8601 format (yyyy-MM-ddTHH:mm:ss.fffZ) *)
 	timestamp : STRING(24);

--- a/Test PLC/Tester/POUs/FB_InterfaceTest.TcPOU
+++ b/Test PLC/Tester/POUs/FB_InterfaceTest.TcPOU
@@ -4,6 +4,7 @@
     <Declaration><![CDATA[(*
 	Function block to assign to an ITest interface
 *)
+{attribute 'NotBlockWritable'}
 FUNCTION_BLOCK FB_InterfaceTest IMPLEMENTS ITest
 VAR
 	(* Last Value *)

--- a/Test PLC/Tester/POUs/FB_TestBlock.TcPOU
+++ b/Test PLC/Tester/POUs/FB_TestBlock.TcPOU
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
   <POU Name="FB_TestBlock" Id="{e27b484d-fa08-4831-aa6b-0b445933cd95}" SpecialFunc="None">
-    <Declaration><![CDATA[FUNCTION_BLOCK FB_TestBlock
+    <Declaration><![CDATA[{attribute 'NotBlockWritable'}
+FUNCTION_BLOCK FB_TestBlock
 VAR_INPUT
 	(* Time between calls to the interface *)
 	delayUpdates : TIME;

--- a/Test PLC/Tester/POUs/FB_TestBlock.TcPOU
+++ b/Test PLC/Tester/POUs/FB_TestBlock.TcPOU
@@ -18,6 +18,7 @@ VAR
 	(* Counter of calls made with a return of TRUE *)
 	trueCallCount : UINT;
 	(* Timer for the call *)
+	{attribute 'ReadOnly'}
 	callTimer : TON;
 	(* Reference to another Function Block of the same time *)
 	selfTypeReference : REFERENCE TO FB_TestBlock;

--- a/Test PLC/Tester/POUs/MAIN.TcPOU
+++ b/Test PLC/Tester/POUs/MAIN.TcPOU
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
   <POU Name="MAIN" Id="{0be89959-27fb-4658-95b3-249248bfd9c7}" SpecialFunc="None">
-    <Declaration><![CDATA[PROGRAM MAIN
+    <Declaration><![CDATA[{attribute 'NotBlockWritable'}
+PROGRAM MAIN
 VAR
 	(* Boolean *)
 	boolean : BOOL;
@@ -41,10 +42,13 @@ VAR
 	item : U_EveryType;
 	
 	(* Windows time *)
+	{attribute 'NotBlockWritable'}
 	fbTime   : FB_LocalSystemTime := ( bEnable := TRUE, dwCycle := 1 );
 	(* Windows time zone *)
+	{attribute 'NotBlockWritable'}
 	fbTimeZone : FB_GetTimeZoneInformation := (bExecute := TRUE);
 	(* Converts local Windows time to UTC *)
+	{attribute 'NotBlockWritable'}
 	fbToUTC : FB_TzSpecificLocalTimeToSystemTime;
 END_VAR
 

--- a/Test PLC/Tester/Tester.plcproj
+++ b/Test PLC/Tester/Tester.plcproj
@@ -16,6 +16,10 @@
     <Implicit_KindOfTask>{624065f8-a9ad-42b9-826a-47c82d8fedc6}</Implicit_KindOfTask>
     <Implicit_Jitter_Distribution>{cf9c5036-687b-4724-b405-cb41e78ba8c1}</Implicit_Jitter_Distribution>
     <LibraryReferences>{98fd708e-e221-4888-9794-091331848200}</LibraryReferences>
+    <Released>false</Released>
+    <AllowChecksForLibrary>false</AllowChecksForLibrary>
+    <POUsForPropertyAccessIncluded>false</POUsForPropertyAccessIncluded>
+    <GlobalVersionStructureIncluded>false</GlobalVersionStructureIncluded>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DUTs\E_TestEnum.TcDUT">
@@ -79,8 +83,8 @@
   <ProjectExtensions>
     <PlcProjectOptions>
       <XmlArchive>
-  <Data>
-    <o xml:space="preserve" t="OptionKey">
+        <Data>
+          <o xml:space="preserve" t="OptionKey">
       <v n="Name">"&lt;ProjectRoot&gt;"</v>
       <d n="SubKeys" t="Hashtable" ckt="String" cvt="OptionKey">
         <v>{192FAD59-8248-4824-A8DE-9177C94C195A}</v>
@@ -141,14 +145,14 @@
       </d>
       <d n="Values" t="Hashtable" />
     </o>
-  </Data>
-  <TypeList>
-    <Type n="Boolean">System.Boolean</Type>
-    <Type n="Hashtable">System.Collections.Hashtable</Type>
-    <Type n="OptionKey">{54dd0eac-a6d8-46f2-8c27-2f43c7e49861}</Type>
-    <Type n="String">System.String</Type>
-  </TypeList>
-</XmlArchive>
+        </Data>
+        <TypeList>
+          <Type n="Boolean">System.Boolean</Type>
+          <Type n="Hashtable">System.Collections.Hashtable</Type>
+          <Type n="OptionKey">{54dd0eac-a6d8-46f2-8c27-2f43c7e49861}</Type>
+          <Type n="String">System.String</Type>
+        </TypeList>
+      </XmlArchive>
     </PlcProjectOptions>
   </ProjectExtensions>
 </Project>

--- a/src/Attributes/BlockWriteNotAllowedAttribute.cs
+++ b/src/Attributes/BlockWriteNotAllowedAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace AdsSimplifiedInterface.Attributes
+{
+    /// <summary>
+    /// Marks the PLC variable as read-only. (i.e. the AdsSimplifiedInterface will not write to the PLC variable)
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Field)]
+    public class BlockWriteNotAllowedAttribute : Attribute
+    {
+    }
+}

--- a/src/Attributes/ReadOnlyAttribute.cs
+++ b/src/Attributes/ReadOnlyAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace AdsSimplifiedInterface.Attributes
+{
+    /// <summary>
+    /// Marks the PLC variable as read-only. (i.e. the AdsSimplifiedInterface will not write to the PLC variable)
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Field)]
+    public class ReadOnlyAttribute : Attribute
+    {
+    }
+}

--- a/src/Data Type/AdsTypeCreator.cs
+++ b/src/Data Type/AdsTypeCreator.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using AdsSimplifiedInterface.Attributes;
+using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -33,6 +34,14 @@ namespace AdsSimplifiedInterface
         /// Constructor for adding MarshalAs(marshalType)
         /// </summary>
         private readonly ConstructorInfo _marshalType = typeof(MarshalAsAttribute).GetConstructor([typeof(UnmanagedType)]) ?? throw new InvalidOperationException("MarshalAs doesn't define a constructor with just the unmanaged type");
+        /// <summary>
+        /// Constructor for adding MarshalAs(marshalType)
+        /// </summary>
+        private readonly ConstructorInfo _readOnlyAttribute = typeof(ReadOnlyAttribute).GetConstructor([]) ?? throw new InvalidOperationException("Read Only Attribute doesn't define a constructor with just the unmanaged type");
+        /// <summary>
+        /// Constructor for adding MarshalAs(marshalType)
+        /// </summary>
+        private readonly ConstructorInfo _blockWriteNotAllowedAttribute = typeof(BlockWriteNotAllowedAttribute).GetConstructor([]) ?? throw new InvalidOperationException("Block Write Not Allowed Attribute doesn't define a constructor with just the unmanaged type");
         /// <summary>
         /// Constant size field of the MarshalAs attribute
         /// </summary>
@@ -75,6 +84,13 @@ namespace AdsSimplifiedInterface
             if (_cache.TryGetValue(dataType.FullName, out Type? value))
             {
                 return value;
+            }
+
+            // Search the defined types
+            if (Type.GetType(dataType.FullName) is Type systemType)
+            {
+                _cache[dataType.FullName] = systemType;
+                return systemType;
             }
 
             _logger.LogDebug($"Starting {dataType.FullName} creation");
@@ -120,10 +136,14 @@ namespace AdsSimplifiedInterface
 
             _logger.LogDebug($"Starting {dataType.FullName} structure creation");
 
+            // Create the structure
             TypeBuilder builder = _moduleBuilder.DefineType(dataType.Name, TypeAttributes.SequentialLayout);
 
+            // Add the members
+            bool BlockWriteNotAllowed = false;
             int offset = 0;
             int alignment;
+            int alignmentNumber = 1;
             foreach (IMember member in dataType.Members)
             {
                 _logger.LogDebug($"Starting {member.InstancePath} addition");
@@ -140,13 +160,25 @@ namespace AdsSimplifiedInterface
                 if (alignment > 0)
                 {
                     _logger.LogDebug($"Adding a {alignment} alignment before {member.InstancePath}");
-                    CreateAlignment(alignment, ref builder);
+                    CreateAlignment(alignment, alignmentNumber, ref builder);
+                    alignmentNumber++;
                     offset += alignment;
                 }
 
                 // Create the field
                 FieldBuilder field = builder.DefineField(member.InstanceName, CreateType(member.DataType), FieldAttributes.Public);
                 SetAttributes(member.DataType, ref field);
+
+                // Check if the field is read only
+                if (member.Attributes.Contains("ReadOnly"))
+                {
+                    field.SetCustomAttribute(new CustomAttributeBuilder(_readOnlyAttribute, []));
+                    BlockWriteNotAllowed = true;
+                }
+                else if (ReadOnlyVariable(member.DataType))
+                {
+                    BlockWriteNotAllowed = true;
+                }
 
                 // Update offset
                 offset += member.ByteSize;
@@ -159,7 +191,19 @@ namespace AdsSimplifiedInterface
             if (alignment > 0)
             {
                 _logger.LogDebug($"Adding a {alignment} alignment at the end of {dataType.FullName}");
-                CreateAlignment(alignment, ref builder);
+                CreateAlignment(alignment, alignmentNumber, ref builder);
+            }
+
+            // Check if the structure is block writable or not
+            if (BlockWriteNotAllowed)
+            {
+                builder.SetCustomAttribute(new CustomAttributeBuilder(_blockWriteNotAllowedAttribute, []));
+            }
+
+            // Check if the structure is read only
+            if (ReadOnlyVariable(dataType))
+            {
+                builder.SetCustomAttribute(new CustomAttributeBuilder(_readOnlyAttribute, []));
             }
 
             // Cache the type and return
@@ -185,8 +229,10 @@ namespace AdsSimplifiedInterface
 
             _logger.LogDebug($"Starting {dataType.FullName} array creation");
 
+            // Create the element type
             IDataType elementType = dataType.ElementType ?? throw new InvalidOperationException($"{dataType.FullName} does not have an element data type");
 
+            // Create the array type, cache, and return
             Type type = CreateType(elementType).MakeArrayType();
             _cache[dataType.FullName] = type;
             return type;
@@ -236,8 +282,10 @@ namespace AdsSimplifiedInterface
 
             _logger.LogDebug($"Starting {dataType.FullName} enum creation");
 
+            // Build the enumeration
             EnumBuilder builder = _moduleBuilder.DefineEnum(dataType.Name, TypeAttributes.Public, CreateType(dataType.BaseType ?? throw new InvalidOperationException($"{dataType.FullName} does not have an underlying type")));
 
+            // Add the values
             foreach (IEnumValue enumValue in dataType.EnumValues)
             {
                 _logger.LogDebug($"Starting {enumValue.Name} addition");
@@ -434,8 +482,10 @@ namespace AdsSimplifiedInterface
 
             _logger.LogDebug($"Starting {dataType.FullName} union creation");
 
+            // Build the union
             TypeBuilder builder = _moduleBuilder.DefineType(dataType.Name, TypeAttributes.ExplicitLayout);
 
+            // Fetch the members and add them to the union
             foreach (IField member in dataType.Fields)
             {
                 _logger.LogDebug($"Starting {member.InstancePath} addition");
@@ -447,12 +497,17 @@ namespace AdsSimplifiedInterface
                     continue;
                 }
 
-                // Create the field
+                // Protect against invalid types
                 if (member.DataType is IStringType)
                 {
                     throw new NotImplementedException($"{member.InstancePath} is not able to be handled right now because it is a string and C# doesn't like unions with strings");
                 }
+                if (ReadOnlyVariable(member.DataType))
+                {
+                    throw new InvalidOperationException($"{member.InstancePath} is not valid because the member's type is read only");
+                }
 
+                // Create the field and add attributes
                 FieldBuilder field = builder.DefineField(member.InstanceName, CreateType(member.DataType), FieldAttributes.Public);
                 SetAttributes(member.DataType, ref field);
                 field.SetOffset(0);
@@ -496,6 +551,7 @@ namespace AdsSimplifiedInterface
         /// <param name="fieldBuilder">Field to marshal</param>
         private void SetAttributes(IDataType dataType, ref FieldBuilder fieldBuilder)
         {
+            // Handle Marshalling for the field
             if (dataType is IArrayType value)
             {
                 if (value.ElementType!.Name.Equals("bool", StringComparison.OrdinalIgnoreCase))
@@ -518,14 +574,21 @@ namespace AdsSimplifiedInterface
             {
                 fieldBuilder.SetCustomAttribute(new CustomAttributeBuilder(_marshalType, [UnmanagedType.ByValTStr], [_marshalConstSize], [dataType.ByteSize]));
             }
+
+            // Handle read-only fields
+            if (ReadOnlyVariable(dataType))
+            {
+                fieldBuilder.SetCustomAttribute(new CustomAttributeBuilder(_readOnlyAttribute, []));
+            }
         }
 
         /// <summary>
         /// Creates an alignment entry into the data type
         /// </summary>
         /// <param name="Size">Size of the alignment</param>
+        /// <param name="AlignmentNumber">Number of the alignment</param>
         /// <param name="typeBuilder">Type builder to add the alignment to</param>
-        private void CreateAlignment(int Size, ref TypeBuilder typeBuilder)
+        private void CreateAlignment(int Size, int AlignmentNumber, ref TypeBuilder typeBuilder)
         {
             if (Size == 0)
             {
@@ -533,14 +596,29 @@ namespace AdsSimplifiedInterface
             }
             else if (Size == 1)
             {
-                typeBuilder.DefineField("Alignment" + Guid.NewGuid().ToString(), typeof(byte), FieldAttributes.Private);
+                typeBuilder.DefineField("Alignment" + AlignmentNumber.ToString(), typeof(byte), FieldAttributes.Private);
                 return;
             }
             else
             {
-                FieldBuilder fieldBuilder = typeBuilder.DefineField("Alignment" + Guid.NewGuid().ToString(), typeof(byte[]), FieldAttributes.Private);
+                FieldBuilder fieldBuilder = typeBuilder.DefineField("Alignment" + AlignmentNumber.ToString(), typeof(byte[]), FieldAttributes.Private);
                 fieldBuilder.SetCustomAttribute(new CustomAttributeBuilder(_marshalType, [UnmanagedType.ByValArray], [_marshalConstSize], [Size]));
             }
+        }
+
+        /// <summary>
+        /// Determines if a variable is read-only
+        /// </summary>
+        /// <param name="dataType">Data type information</param>
+        /// <returns>True if the variable is a read only variable</returns>
+        public static bool ReadOnlyVariable(IDataType? dataType)
+        {
+            if (dataType == null)
+            {
+                return false;
+            }
+
+            return dataType.Attributes.Contains("ReadOnly") || (dataType is IInterfaceType && dataType is not IStructType) || dataType is IPointerType || dataType is IReferenceType;
         }
         #endregion
     }

--- a/src/Data Type/AdsTypeInfoCreator.cs
+++ b/src/Data Type/AdsTypeInfoCreator.cs
@@ -132,7 +132,7 @@ namespace AdsSimplifiedInterface
                 memberInfo.DataType = memberInfo.Name;
                 memberInfo.Name = member.InstanceName;
                 plcVariableTypeInfo.Children.Add(memberInfo);
-                plcVariableTypeInfo.IsBlockWriteAllowed &= memberInfo.IsBlockWriteAllowed;
+                plcVariableTypeInfo.IsBlockWriteAllowed &= memberInfo.IsBlockWriteAllowed && !memberInfo.IsReadOnly;
 
                 _logger.LogDebug($"{member.InstancePath} added with next offset at {member.ByteOffset}");
             }

--- a/src/Data Type/AdsTypeInfoCreator.cs
+++ b/src/Data Type/AdsTypeInfoCreator.cs
@@ -107,7 +107,7 @@ namespace AdsSimplifiedInterface
                 Size = dataType.ByteSize,
                 Offset = 0,
                 DataType = dataType.Name,
-                IsBlockWriteAllowed = !(dataType.Category == DataTypeCategory.FunctionBlock || dataType.Category == DataTypeCategory.Program),
+                IsBlockWriteAllowed = !(dataType.Category == DataTypeCategory.FunctionBlock || dataType.Category == DataTypeCategory.Program) && !dataType.Attributes.Contains("NotBlockWritable"),
                 Comment = dataType.Comment,
                 Attributes = dataType.Attributes.ToDictionary(x => x.Name, x => x.Value)
             };
@@ -171,6 +171,8 @@ namespace AdsSimplifiedInterface
                 IsArray = true,
                 ArraySize = dataType.ByteSize / dataType.ElementType.ByteSize,
                 Comment = dataType.Comment,
+                IsReadOnly = dataType.Attributes.Contains("ReadOnly") || dataType.ElementType.Attributes.Contains("ReadOnly"),
+                IsBlockWriteAllowed = !(dataType.Attributes.Contains("NotBlockWritable") || dataType.Attributes.Contains("ReadOnly") || dataType.ElementType.Attributes.Contains("NotBlockWritable") || dataType.ElementType.Attributes.Contains("ReadOnly") || dataType.ElementType.Category == DataTypeCategory.String),
                 Attributes = dataType.Attributes.ToDictionary(x => x.Name, x => x.Value)
             };
             type.DataType += "[]";
@@ -237,6 +239,8 @@ namespace AdsSimplifiedInterface
                 IsEnum = true,
                 DataType = "enum",
                 Comment = dataType.Comment,
+                IsReadOnly = dataType.Attributes.Contains("ReadOnly"),
+                IsBlockWriteAllowed = !(dataType.Attributes.Contains("NotBlockWritable") || dataType.Attributes.Contains("ReadOnly")),
                 Attributes = dataType.Attributes.ToDictionary(x => x.Name, x => x.Value)
             };
 
@@ -379,6 +383,8 @@ namespace AdsSimplifiedInterface
             {
                 DataType = dataType.Name,
                 Comment = dataType.Comment,
+                IsReadOnly = dataType.Attributes.Contains("ReadOnly") || dataType.BaseType.Attributes.Contains("ReadOnly"),
+                IsBlockWriteAllowed = !(dataType.Attributes.Contains("NotBlockWritable") || dataType.Attributes.Contains("ReadOnly") || dataType.BaseType.Attributes.Contains("NotBlockWritable") || dataType.BaseType.Attributes.Contains("ReadOnly")),
                 Attributes = dataType.Attributes.ToDictionary(x => x.Name, x => x.Value)
             };
             _cache[dataType.FullName] = type;
@@ -599,6 +605,8 @@ namespace AdsSimplifiedInterface
                 PlcVariableTypeInfo memberInfo = new(CreateType(member.DataType))
                 {
                     Offset = 0,
+                    IsReadOnly = member.Attributes.Contains("ReadOnly"),
+                    IsBlockWriteAllowed = !(member.Attributes.Contains("NotBlockWritable") || member.Attributes.Contains("ReadOnly")),
                     Comment = member.Comment
                 };
                 memberInfo.DataType = memberInfo.Name;
@@ -642,6 +650,8 @@ namespace AdsSimplifiedInterface
             {
                 DataType = dataType.Name,
                 Comment = dataType.Comment,
+                IsReadOnly = dataType.Attributes.Contains("ReadOnly") || dataType.BaseType.Attributes.Contains("ReadOnly"),
+                IsBlockWriteAllowed = !(dataType.Attributes.Contains("NotBlockWritable") || dataType.Attributes.Contains("ReadOnly") || dataType.BaseType.Attributes.Contains("NotBlockWritable") || dataType.BaseType.Attributes.Contains("ReadOnly")),
                 Attributes = dataType.Attributes.ToDictionary(x => x.Name, x => x.Value)
             };
             _cache[dataType.FullName] = type;


### PR DESCRIPTION
Added attributes for disabling block writing of structures, pointers, references, and interfaces.  This prevents overwriting a critical pointer for the PLC.

Added pragma "ReadOnly" and "NotBlockWritable" for telling the interface which variables to include for the blocking of writing.  The "ReadOnly" blocks all writing, the "NotBlockWritable" only prevents writing the variable as a single block of data. 